### PR TITLE
Allow easier local customisation

### DIFF
--- a/source/_includes/custom/navigation.html
+++ b/source/_includes/custom/navigation.html
@@ -1,0 +1,6 @@
+        <ul class="nav">
+          <li><a href="{{ root_url }}/">Home</a></li>
+          <li><a href="{{ root_url }}/blog/archives">Blog</a></li>
+          <li><a href="{{ root_url }}/projects">Projects</a></li>
+          <li><a href="{{ root_url }}/contact">Contact</a></li>
+        </ul>

--- a/source/_includes/header.html
+++ b/source/_includes/header.html
@@ -1,13 +1,21 @@
+{% if site.subscribe_email or site.subscribe_rss or site.twitter_user %}
 <div class="subscribe">
   <table>
     <tr>
       <td><span>Get Updates: &nbsp;</span></td>
+      {% if site.subscribe.email %}
       <td><a href="#" onclick="window.open('{{site.subscribe_email}}','FeedBurner','menubar=no,width=600,height=600,toolbar=no'); return false;" class="btn"><i class="icon-envelope"></i> By Email</a></td>
+      {% endif %}
+      {% if site.subscribe_rss %}
       <td><a href="{{site.subscribe_rss}}" class="btn"><i class="icon-cog"></i> By RSS</a></td>
+      {% endif %}
+      {% if site.twitter_user %}
       <td><a href="http://twitter.com/{{site.twitter_user}}" class="btn"><i class="icon-twitter-sign"></i> On Twitter</a></td>
+      {% endif %}
     </tr>
   </table>
 </div>
+{% endif %}
 <h1 class="title">{{ site.title }}</h1>
 {% if site.subtitle %}
   <p class="lead">{{ site.subtitle }}</p>

--- a/source/_includes/navigation.html
+++ b/source/_includes/navigation.html
@@ -7,12 +7,7 @@
         <span class="icon-bar"></span>
       </a>
       <div class="nav-collapse">
-        <ul class="nav">
-          <li><a href="{{ root_url }}/">Home</a></li>
-          <li><a href="{{ root_url }}/blog/archives">Blog</a></li>
-          <li><a href="{{ root_url }}/projects">Projects</a></li>
-          <li><a href="{{ root_url }}/contact">Contact</a></li>
-        </ul>
+        {% include custom/navigation.html %}
         {% if site.simple_search %}
           <form action="{{ site.simple_search }}" method="get" class="navbar-search pull-left">
             <fieldset role="search">
@@ -21,11 +16,13 @@
             </fieldset>
           </form>
         {% endif %}
+        {% if site.feedburner_url %}
         <ul class="nav pull-right">
           <li>
-            <a style="padding: 7px 0 0 0;" href="http://feeds.feedburner.com/brianarmstrong/vTOG"><img src="http://feeds.feedburner.com/~fc/brianarmstrong/vTOG?bg=a1cefc&amp;fg=444444&amp;anim=0" height="26" width="88" style="border:0" alt="" /></a>            
+            <a style="padding: 7px 0 0 0;" href="{{ site.feedburner_url }}"><img src="{{ site.feedburner_img_url }}&amp;fg=444444&amp;anim=0" height="26" width="88" style="border:0" alt="" /></a>            
           </li>
         </ul>
+        {% endif %}
       </div><!-- /.nav-collapse -->
     </div>
   </div><!-- /navbar-inner -->

--- a/source/_includes/sidebar.html
+++ b/source/_includes/sidebar.html
@@ -1,5 +1,5 @@
 {% unless page.sidebar == false %}
-  <div class="span4 sidebar">
+  <div class="span{{ site.sidebar_width or 4 }} sidebar">
     <div class="well">
       {% if site.page_asides.size %}
         {% include_array page_asides %}

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -3,6 +3,9 @@ layout: default
 ---
 
 <div class="row">
+  {% if page.sidebar and site.sidebar_posn == "left" %}
+    {% include sidebar.html %}
+  {% endif %}
   <div class="{% if page.sidebar == false %}span12{% else %}span8{% endif %}">
     {% if page.title %}
       <div class="page-header">
@@ -33,5 +36,7 @@ layout: default
       </section>
     {% endif %}
   </div>
-  {% include sidebar.html %}
+  {% if page.sidebar and site.sidebar_posn != "left" %}
+    {% include sidebar.html %}
+  {% endif %}
 </div>

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -1,10 +1,14 @@
 ---
 layout: default
 single: true
+# page.sidebar is not necessarily set for pages - assume true if not set
 ---
 
 <div class="row">
-  <div class="{% if page.sidebar == false %}span12{% else %}span8{% endif %}">
+  {% if page.sidebar != false and site.sidebar_posn == "left" %}
+    {% include sidebar.html %}
+  {% endif %}
+  <div class="{% if page.sidebar != false %}span8{% else %}span12{% endif %}">
     {% include article.html %}
     <footer>
       <p class="meta">
@@ -17,10 +21,10 @@ single: true
       {% endunless %}
       <p class="meta">
         {% if page.previous.url %}
-          <a class="basic-alignment left" href="{{page.previous.url}}" title="Previous Post: {{page.previous.title}}">&laquo; {{page.previous.title}}</a>
+          <a class="basic-alignment pull-left" href="{{page.previous.url}}" title="Previous Post: {{page.previous.title}}">&laquo; {{page.previous.title}}</a>
         {% endif %}
         {% if page.next.url %}
-          <a class="basic-alignment right" href="{{page.next.url}}" title="Next Post: {{page.next.title}}">{{page.next.title}} &raquo;</a>
+          <a class="basic-alignment pull-right" href="{{page.next.url}}" title="Next Post: {{page.next.title}}">{{page.next.title}} &raquo;</a>
         {% endif %}
       </p>
     </footer>
@@ -33,6 +37,8 @@ single: true
     {% endif %}
   </div>
 
-  {% include sidebar.html %}
+  {% if page.sidebar != false and site.sidebar_posn != "left" %}
+    {% include sidebar.html %}
+  {% endif %}
 </div>
 

--- a/source/index.html
+++ b/source/index.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 
+{% if site.sidebar_posn == "left" %}
+  {% include sidebar.html %}
+{% endif %}
 <div class="blog-index">
   {% assign index = true %}
   {% for post in paginator.posts %}
@@ -20,10 +23,6 @@ layout: default
     {% endif %}
   </div>
 </div>
-<aside class="sidebar">
-  {% if site.blog_index_asides.size %}
-    {% include_array blog_index_asides %}
-  {% else %}
-    {% include_array default_asides %}
-  {% endif %}
-</aside>
+{% if site.sidebar_posn != "left" %}
+  {% include sidebar.html %}
+{% endif %}


### PR DESCRIPTION
Allow nav bar to be generated from custom/navigation (as default theme)
Change feedburner to use bespoke feedburner settings
- site.feedburner_url - feedburner url for feed
- site.feedburner_img_url - image for feedcount
  Made subscribe buttons hide if no value set
  Sidebar can be on left or right.
  index.html includes sidebar.html for reuse

I'd rather remove _includes/custom/navigation.html from the repo entirely but I guess it's nice to have a default
This will break your pages until you add feedburner_url and feedburner_img_url to your _config.yml
